### PR TITLE
Fix duplicate radio font entries in config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,12 +58,6 @@ display:
     sample_rate_khz:
       path: "/home/volumio/Quadify/src/assets/fonts/OpenSans-Regular.ttf"
       size: 12
-    radio_title:
-      path: "/home/volumio/Quadify/src/assets/fonts/OpenSans-Regular.ttf"
-      size: 15
-    radio_bitrate:
-      path: "/home/volumio/Quadify/src/assets/fonts/OpenSans-Regular.ttf"
-      size: 12
     volume_small:
       path: "/home/volumio/Quadify/src/assets/fonts/OpenSans-Regular.ttf"
       size: 8


### PR DESCRIPTION
## Summary
- remove redundant `radio_title` and `radio_bitrate` font definitions

## Testing
- `python` script to parse fonts section of `config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_683f3e478bfc833193a2db8dcef70386