### PR TITLE
Implement universal back navigation

### DIFF
--- a/src/display/screens/system_info_screen.py
+++ b/src/display/screens/system_info_screen.py
@@ -202,3 +202,8 @@ class SystemInfoScreen(BaseManager):
         except Exception:
             pass
         return []
+
+    def back(self):
+        if self.is_active:
+            self.stop_mode()
+        self.mode_manager.back()

--- a/src/hardware/ir_listener.py
+++ b/src/hardware/ir_listener.py
@@ -92,7 +92,7 @@ def process_key(key, current_mode):
             print("No mapping for KEY_DOWN in current mode.")
 
     
-    elif key == "KEY_BACK":
+    elif key in ["KEY_BACK", "KEY_EXIT", "KEY_RETURN"]:
         send_command("back")
 
     elif key == "KEY_POWER":

--- a/src/main.py
+++ b/src/main.py
@@ -540,22 +540,10 @@ def main():
 
     def on_button_press_ui():
         current_mode = mode_manager.get_mode()
-        if current_mode == 'clock':
+        if current_mode in mode_manager.menu_modes:
+            mode_manager.back()
+        elif current_mode == 'clock':
             mode_manager.trigger("to_menu")
-        elif current_mode == 'menu':
-            mode_manager.menu_manager.select_item()
-        elif current_mode == 'configmenu':
-            mode_manager.config_menu.select_item()
-        elif current_mode == 'remotemenu':
-            mode_manager.remote_menu.select_item()
-        elif current_mode == 'systemupdate':
-            mode_manager.system_update_menu.select_item()
-        elif current_mode == 'screensavermenu':
-            mode_manager.screensaver_menu.select_item()
-        elif current_mode == 'displaymenu':
-            mode_manager.display_menu.select_item()
-        elif current_mode == 'clockmenu':
-            mode_manager.clock_menu.select_item()
         elif current_mode in ['original', 'modern', 'minimal']:
             logger.info(f"Button pressed in {current_mode} mode; toggling playback.")
             if current_mode == 'original':
@@ -570,24 +558,6 @@ def main():
                 screen.toggle_play_pause()
             else:
                 logger.warning(f"No screen instance found for mode: {current_mode}")
-        elif current_mode == 'playlists':
-            mode_manager.playlist_manager.select_item()
-        elif current_mode == 'tidal':
-            mode_manager.tidal_manager.select_item()
-        elif current_mode == 'qobuz':
-            mode_manager.qobuz_manager.select_item()
-        elif current_mode == 'spotify':
-            mode_manager.spotify_manager.select_item()
-        elif current_mode == 'library':
-            mode_manager.library_manager.select_item()
-        elif current_mode == 'radiomanager':
-            mode_manager.radio_manager.select_item()
-        elif current_mode == 'motherearthradio':
-            mode_manager.motherearth_manager.select_item()
-        elif current_mode == 'radioparadise':
-            mode_manager.radioparadise_manager.select_item()
-        elif current_mode == 'usblibrary':
-            mode_manager.usb_library_manager.select_item()
         elif current_mode == 'screensaver':
             mode_manager.exit_screensaver()
         else:

--- a/src/managers/base_manager.py
+++ b/src/managers/base_manager.py
@@ -57,3 +57,7 @@ class BaseManager(ABC):
     def clear_display(self):
         self.display_manager.clear_screen()
         self.logger.info("Cleared the display screen.")
+
+    def back(self):
+        """Default back action delegates to ModeManager."""
+        self.mode_manager.back()

--- a/src/managers/menus/base_manager.py
+++ b/src/managers/menus/base_manager.py
@@ -57,3 +57,7 @@ class BaseManager(ABC):
     def clear_display(self):
         self.display_manager.clear_screen()
         self.logger.info("Cleared the display screen.")
+
+    def back(self):
+        """Default back action delegates to ModeManager."""
+        self.mode_manager.back()

--- a/src/managers/menus/clock_menu.py
+++ b/src/managers/menus/clock_menu.py
@@ -169,10 +169,10 @@ class ClockMenu(BaseManager):
                 self._draw_current_menu()
 
             elif selected == "Back":
-                # Return to Display Menu
-                self.logger.info("ClockMenu: 'Back' => to Display Menu")
+                # Go back to the previous menu
+                self.logger.info("ClockMenu: 'Back' => back action")
                 self.stop_mode()
-                self.mode_manager.to_displaymenu()
+                self.mode_manager.back()
 
             else:
                 self.logger.warning(f"ClockMenu: Unknown main item => {selected}")
@@ -303,3 +303,8 @@ class ClockMenu(BaseManager):
             self.mode_manager.save_preferences()
         else:
             self.logger.warning(f"ClockMenu: Unknown font => {selected}")
+
+    def back(self):
+        if self.is_active:
+            self.stop_mode()
+        self.mode_manager.back()

--- a/src/managers/menus/config_menu.py
+++ b/src/managers/menus/config_menu.py
@@ -175,6 +175,11 @@ class ConfigMenu(BaseManager):
         elif selected == "IRremote":
             self.mode_manager.to_remotemenu()
         elif selected == "Back":
-            self.mode_manager.to_menu()
+            self.mode_manager.back()
         else:
             self.logger.warning(f"ConfigMenu: Unrecognised selection: {selected}")
+
+    def back(self):
+        if self.is_active:
+            self.stop_mode()
+        self.mode_manager.back()

--- a/src/managers/menus/display_menu.py
+++ b/src/managers/menus/display_menu.py
@@ -168,9 +168,9 @@ class DisplayMenu(BaseManager):
                 self._display_current_menu()
 
             elif selected_item == "Back":
-                # Return to config menu
+                # Go back to the previous menu/screen
                 self.stop_mode()
-                self.mode_manager.to_configmenu()
+                self.mode_manager.back()
             else:
                 self.logger.warning(f"DisplayMenu: Unknown main item => {selected_item}")
 
@@ -343,3 +343,8 @@ class DisplayMenu(BaseManager):
             self.mode_manager.save_preferences()
         else:
             self.logger.warning(f"DisplayMenu: Unknown brightness => {level}")
+
+    def back(self):
+        if self.is_active:
+            self.stop_mode()
+        self.mode_manager.back()

--- a/src/managers/menus/library_manager.py
+++ b/src/managers/menus/library_manager.py
@@ -188,6 +188,7 @@ class LibraryManager(BaseManager):
                 }
                 for item in items
             ]
+            self.current_menu_items.append({"title": "Back", "uri": None, "type": "back"})
 
             self.logger.info(f"LibraryManager: Fetched {len(self.current_menu_items)} items for URI: {uri}")
             if self.is_active:
@@ -208,6 +209,10 @@ class LibraryManager(BaseManager):
 
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"LibraryManager: Selected item: {selected_item}")
+
+        if selected_item.get("title") == "Back":
+            self.back()
+            return
 
         if 'action' in selected_item:
             # Handle submenu actions
@@ -578,6 +583,14 @@ class LibraryManager(BaseManager):
 
         # Log or display the extracted information
         self.logger.info(f"Sample Rate: {sample_rate}, Bit Depth: {bitdepth}, Volume: {volume}")
+
+    def back(self):
+        if self.menu_stack:
+            self.pop_menu()
+        else:
+            if self.is_active:
+                self.stop_mode()
+            self.mode_manager.back()
 
         # Optional: Update the screen with this information if needed
         # You can call methods on `self.display_manager` or another appropriate object

--- a/src/managers/menus/playlist_manager.py
+++ b/src/managers/menus/playlist_manager.py
@@ -154,6 +154,7 @@ class PlaylistManager(BaseManager):
             }
             for item in combined_items
         ]
+        self.current_menu_items.append({"title": "Back", "uri": None, "type": "back"})
 
         self.logger.info(f"PlaylistManager: Updated menu with {len(self.current_menu_items)} items.")
         if self.is_active:
@@ -237,6 +238,9 @@ class PlaylistManager(BaseManager):
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"PlaylistManager: Selected item: {selected_item}")
         name = selected_item.get("title")
+        if name == "Back":
+            self.back()
+            return
         if not name:
             self.logger.warning("PlaylistManager: Selected item has no name.")
             self.display_error_message("Invalid Selection", "Selected item has no name.")
@@ -313,3 +317,8 @@ class PlaylistManager(BaseManager):
         bitdepth = state.get("bitdepth", "Unknown Bit Depth")
         volume = state.get("volume", "Unknown Volume")
         self.logger.info(f"Sample Rate: {sample_rate}, Bit Depth: {bitdepth}, Volume: {volume}")
+
+    def back(self):
+        if self.is_active:
+            self.stop_mode()
+        self.mode_manager.back()

--- a/src/managers/menus/qobuz_manager.py
+++ b/src/managers/menus/qobuz_manager.py
@@ -194,6 +194,7 @@ class QobuzManager(BaseManager):
                     }
                     for item in combined_items
                 ]
+                self.current_menu_items.append({"title": "Back", "uri": None, "type": "back"})
                 self.logger.info(f"QobuzManager: Updated menu with {len(self.current_menu_items)} items.")
                 if self.is_active:
                     self.display_menu()
@@ -260,6 +261,10 @@ class QobuzManager(BaseManager):
 
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"QobuzManager: Selected item: {selected_item}")
+
+        if selected_item.get("title") == "Back":
+            self.back()
+            return
 
         uri = selected_item.get("uri")
         if not uri:
@@ -333,6 +338,14 @@ class QobuzManager(BaseManager):
         self.window_start_index = previous_context["window_start_index"]
         self.logger.debug("QobuzManager: Restored previous menu context from stack.")
         self.display_menu()
+
+    def back(self):
+        if self.menu_stack:
+            self.go_back()
+        else:
+            if self.is_active:
+                self.stop_mode()
+            self.mode_manager.back()
 
     def handle_toast_message(self, sender, message):
         """Handle toast messages from Volumio, especially errors."""

--- a/src/managers/menus/radio_manager.py
+++ b/src/managers/menus/radio_manager.py
@@ -205,6 +205,7 @@ class RadioManager(BaseManager):
                 item.get("title", item.get("name", "Untitled"))
                 for item in items
             ]
+            self.categories.append("Back")
             self.logger.info(f"RadioManager: Updated categories list with {len(self.categories)} items.")
             self.current_selection_index = 0
             self.window_start_index = 0
@@ -242,6 +243,7 @@ class RadioManager(BaseManager):
                 }
                 for item in items
             ]
+            self.stations.append({"title": "Back", "uri": None})
             self.logger.info(f"RadioManager: Updated stations list with {len(self.stations)} items.")
             self.current_selection_index = 0
             self.window_start_index = 0
@@ -351,6 +353,10 @@ class RadioManager(BaseManager):
             selected_category = self.categories[self.current_selection_index]
             self.logger.info(f"RadioManager: Selected radio category: {selected_category}")
 
+            if selected_category == "Back":
+                self.navigate_back()
+                return
+
             # Fetch the URI for the selected category
             selected_item = self.get_category_item_by_title(selected_category)
             uri = selected_item.get("uri") if selected_item else None
@@ -373,6 +379,10 @@ class RadioManager(BaseManager):
 
             selected_station = self.stations[self.current_selection_index]
             station_title = selected_station['title'].strip()
+
+            if station_title == "Back":
+                self.navigate_back()
+                return
             uri = selected_station['uri']
             albumart_url = selected_station.get('albumart', '')
 
@@ -407,6 +417,14 @@ class RadioManager(BaseManager):
             self.display_categories()
         elif self.current_menu == "stations":
             self.display_radio_stations()
+
+    def back(self):
+        if self.menu_stack:
+            self.navigate_back()
+        else:
+            if self.is_active:
+                self.stop_mode()
+            self.mode_manager.back()
 
     def get_visible_window(self, items):
         """Returns a subset of items to display based on the current selection, keeping it centered."""

--- a/src/managers/menus/remote_menu.py
+++ b/src/managers/menus/remote_menu.py
@@ -138,9 +138,9 @@ class RemoteMenu(BaseManager):
         self.logger.info(f"RemoteMenu: Selected => {selected_item}")
 
         if selected_item == "Back":
-            # Return to the previous (config) menu.
+            # Go back to the previous menu
             self.stop_mode()
-            self.mode_manager.to_configmenu()
+            self.mode_manager.back()
         else:
             # Define the source directory.
             source_dir = f"/home/volumio/Quadify/lirc/configurations/{selected_item}"
@@ -225,4 +225,9 @@ class RemoteMenu(BaseManager):
 
         end_index = self.window_start_index + self.window_size
         return items[self.window_start_index:end_index]
+
+    def back(self):
+        if self.is_active:
+            self.stop_mode()
+        self.mode_manager.back()
 

--- a/src/managers/menus/screensaver_menu.py
+++ b/src/managers/menus/screensaver_menu.py
@@ -156,9 +156,9 @@ class ScreensaverMenu(BaseManager):
         self.logger.info(f"ScreensaverMenu: Selected => {selected_name} (main menu)")
 
         if selected_name == "Back":
-            # Return to config
+            # Go back to the previous menu
             self.stop_mode()
-            self.mode_manager.to_configmenu()
+            self.mode_manager.back()
             return
 
         elif selected_name == "Timer":
@@ -261,3 +261,8 @@ class ScreensaverMenu(BaseManager):
 
         end_index = self.window_start_index + self.window_size
         return items[self.window_start_index:end_index]
+
+    def back(self):
+        if self.is_active:
+            self.stop_mode()
+        self.mode_manager.back()

--- a/src/managers/menus/spotify_manager.py
+++ b/src/managers/menus/spotify_manager.py
@@ -206,6 +206,7 @@ class SpotifyManager(BaseManager):
             }
             for item in combined_items
         ]
+        self.current_menu_items.append({"title": "Back", "uri": None, "type": "back"})
 
         self.logger.info(f"SpotifyManager: Updated menu with {len(self.current_menu_items)} items.")
 
@@ -265,6 +266,10 @@ class SpotifyManager(BaseManager):
 
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"SpotifyManager: Selected item: {selected_item}")
+
+        if selected_item.get("title") == "Back":
+            self.back()
+            return
 
         uri = selected_item.get("uri")
         if not uri:
@@ -327,6 +332,14 @@ class SpotifyManager(BaseManager):
         self.window_start_index = previous_context["window_start_index"]
         self.logger.debug("SpotifyManager: Restored previous menu context from stack.")
         self.display_menu()
+
+    def back(self):
+        if self.menu_stack:
+            self.go_back()
+        else:
+            if self.is_active:
+                self.stop_mode()
+            self.mode_manager.back()
 
     def handle_toast_message(self, sender, message):
         """Handle toast messages from Volumio, especially errors."""

--- a/src/managers/menus/system_update_menu.py
+++ b/src/managers/menus/system_update_menu.py
@@ -141,9 +141,9 @@ class SystemUpdateMenu(BaseManager):
                 self._display_current_menu()
 
             elif selected_item == "Back":
-                # Return to whichever menu invoked us (maybe config menu)
+                # Go back to the previous menu
                 self.stop_mode()
-                self.mode_manager.to_configmenu()
+                self.mode_manager.back()
 
             else:
                 self.logger.warning(f"SystemUpdateMenu: Unknown main item => {selected_item}")
@@ -229,3 +229,8 @@ class SystemUpdateMenu(BaseManager):
         end_index = self.window_start_index + self.window_size
         visible_slice = items[self.window_start_index:end_index]
         return visible_slice
+
+    def back(self):
+        if self.is_active:
+            self.stop_mode()
+        self.mode_manager.back()

--- a/src/managers/menus/tidal_manager.py
+++ b/src/managers/menus/tidal_manager.py
@@ -221,6 +221,7 @@ class TidalManager(BaseManager):
             }
             for item in combined_items
         ]
+        self.current_menu_items.append({"title": "Back", "uri": None, "type": "back"})
 
         self.logger.info(f"TidalManager: Updated menu with {len(self.current_menu_items)} items.")
 
@@ -281,6 +282,9 @@ class TidalManager(BaseManager):
 
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"TidalManager: Selected item: {selected_item}")
+        if selected_item.get("title") == "Back":
+            self.back()
+            return
         uri = selected_item.get("uri")
 
         if not uri:
@@ -355,6 +359,14 @@ class TidalManager(BaseManager):
         self.window_start_index = previous_context["window_start_index"]
         self.logger.debug("TidalManager: Restored previous menu context from stack.")
         self.display_menu()
+
+    def back(self):
+        if self.menu_stack:
+            self.go_back()
+        else:
+            if self.is_active:
+                self.stop_mode()
+            self.mode_manager.back()
 
     def handle_toast_message(self, sender, message, **kwargs):
         """Handle toast messages from Volumio, especially errors."""

--- a/src/managers/menus/usb_library_manager.py
+++ b/src/managers/menus/usb_library_manager.py
@@ -144,6 +144,7 @@ class USBLibraryManager(BaseManager):
             }
             for item in combined_items
         ]
+        self.current_menu_items.append({"title": "Back", "uri": None, "type": "back"})
 
         self.logger.info(f"USBLibraryManager: Updated menu with {len(self.current_menu_items)} items.")
         if self.is_active:
@@ -203,6 +204,9 @@ class USBLibraryManager(BaseManager):
         self.logger.info(f"USBLibraryManager: Selected menu item: {selected_item}")
 
         name = selected_item.get("title")
+        if name == "Back":
+            self.back()
+            return
         uri = selected_item.get("uri")
         if not uri:
             self.logger.warning("USBLibraryManager: Selected item has no URI.")
@@ -266,3 +270,8 @@ class USBLibraryManager(BaseManager):
             )
 
         self.display_manager.draw_custom(draw)
+
+    def back(self):
+        if self.is_active:
+            self.stop_mode()
+        self.mode_manager.back()


### PR DESCRIPTION
## Summary
- map BACK/EXIT/RETURN to `back` in IR listener
- trigger `back` on rotary button press for all menus
- add default `back` handler to base managers
- append `Back` item to menu lists and handle selection
- support `back` in various managers and screens

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fb2f203fc833182384041587ab076