### PR TITLE
Unify menu flow with generic library manager

### DIFF
--- a/src/managers/menu_manager.py
+++ b/src/managers/menu_manager.py
@@ -23,6 +23,8 @@ class MenuManager:
         self.menu_type = menu_type
         self.font_key = 'menu_font'
         self.bold_font_key = 'menu_font_bold'
+        self.line_spacing = 16
+        self.y_offset = 0
         self.lock = threading.Lock()
 
         # Menu label mapping for display
@@ -168,48 +170,27 @@ class MenuManager:
         return mapping.get(plugin, name.upper().replace(' ', '_'))
 
     def draw_menu(self, offset_x=0):
+        """Render the main menu as a text-based list."""
         with self.lock:
             visible_items = self.get_visible_window(self.current_menu_items, self.window_size)
-            icon_size = 40
-            spacing = 10
-            total_width = self.display_manager.oled.width
-            total_height = self.display_manager.oled.height
-            total_icons_width = len(visible_items) * icon_size + (len(visible_items) - 1) * spacing
-            x_offset = (total_width - total_icons_width) // 2 + offset_x
-            y_position = (total_height - icon_size) // 2 - 10
+            font = self.display_manager.fonts.get(self.font_key, ImageFont.load_default())
+            bold_font = self.display_manager.fonts.get(self.bold_font_key, font)
 
-            base_image = Image.new("RGB", self.display_manager.oled.size, "black")
-            draw_obj = ImageDraw.Draw(base_image)
+            def truncate(text, maxlen=20):
+                return text if len(text) <= maxlen else text[: maxlen - 3] + "..."
 
-            for i, item in enumerate(visible_items):
-                actual_index = self.window_start_index + i
-                icon = self.icon_cache.get(item) or self.static_icons.get(item)
-                if not icon:
-                    self.logger.warning(f"No icon cached for {item}, skipping.")
-                    continue
-                if icon.mode == "RGBA":
-                    background = Image.new("RGB", icon.size, (0, 0, 0))
-                    background.paste(icon, mask=icon.split()[3])
-                    icon = background
-                icon = icon.resize((icon_size, icon_size), Image.LANCZOS)
-                x = x_offset + i * (icon_size + spacing)
-                y_adjustment = -5 if actual_index == self.current_selection_index else 0
-                base_image.paste(icon, (x, y_position + y_adjustment))
+            def draw(draw_obj):
+                y = self.y_offset
+                draw_obj.text((0, y), "Main Menu", font=bold_font, fill="yellow")
+                y += self.line_spacing
+                for i, item in enumerate(visible_items):
+                    idx = self.window_start_index + i
+                    label = self.label_map.get(item, item.replace('_', ' ').title())
+                    arrow = "→ " if idx == self.current_selection_index else "  "
+                    fill = "white" if idx == self.current_selection_index else "gray"
+                    draw_obj.text((0, y + i * self.line_spacing), f"{arrow}{truncate(label)}", font=font, fill=fill)
 
-                # Display mapped label or fallback to key
-                label = self.label_map.get(item, item.title().replace('_', ' '))
-                font = self.display_manager.fonts.get(
-                    self.bold_font_key if actual_index == self.current_selection_index else self.font_key,
-                    ImageFont.load_default(),
-                )
-                text_color = "white" if actual_index == self.current_selection_index else "black"
-                tw, th = draw_obj.textsize(label, font=font)
-                text_x = x + (icon_size - tw) // 2
-                text_y = y_position + icon_size - 2
-                draw_obj.text((text_x, text_y), label, font=font, fill=text_color)
-
-            base_image = base_image.convert(self.display_manager.oled.mode)
-            self.display_manager.oled.display(base_image)
+            self.display_manager.draw_custom(draw)
 
     def display_menu(self):
         self.draw_menu(offset_x=0)

--- a/src/managers/menus/library_manager.py
+++ b/src/managers/menus/library_manager.py
@@ -61,10 +61,24 @@ class LibraryManager(BaseManager):
         elif self.is_active:
             self.stop_mode()
 
-    def start_mode(self, start_uri=None):
+    def start_mode(self, service_type=None, start_uri=None):
+        """Activate the library browser.
+
+        Parameters
+        ----------
+        service_type: Optional[str]
+            Set the current service (e.g. 'library', 'tidal').  If omitted the
+            previous value is used.  This allows the same manager instance to be
+            reused for multiple sources.
+        start_uri: Optional[str]
+            Starting URI for navigation.  Defaults to ``self.root_uri``.
+        """
+
         if self.is_active:
             self.logger.debug(f"[{self.service_type}] Already active, ignoring start_mode()")
             return
+        if service_type:
+            self.service_type = service_type
         self.is_active = True
         self.current_selection_index = 0
         self.window_start_index = 0

--- a/src/managers/mode_manager.py
+++ b/src/managers/mode_manager.py
@@ -41,6 +41,7 @@ class ModeManager:
         {'name': 'internal',         'on_enter': 'enter_internal'},
         {'name': 'usblibrary',      'on_enter': 'enter_usb_library'},
         {'name': 'spotify',         'on_enter': 'enter_spotify'},
+        {'name': 'radiomanager',    'on_enter': 'enter_radiomanager'},
         {'name': 'webradio',        'on_enter': 'enter_webradio'},
         {'name': 'motherearthradio', 'on_enter': 'enter_motherearthradio'},
         {'name': 'radioparadise',   'on_enter': 'enter_radioparadise'},
@@ -685,20 +686,41 @@ class ModeManager:
         self.logger.info("ModeManager: Entering 'library' state.")
         self.stop_all_screens()
         if self.library_manager:
-            start_uri = event.kwargs.get('start_uri')
-            self.library_manager.start_mode(start_uri=start_uri)
+            start_uri = event.kwargs.get('start_uri', "music-library")
+            self.library_manager.start_mode(service_type="library", start_uri=start_uri)
             self.logger.info("ModeManager: LibraryManager started.")
         else:
             self.logger.warning("ModeManager: No library_manager set.")
         self.reset_idle_timer()
-        #self.start_menu_inactivity_timer()
+        self.update_current_mode()
+
+    def enter_internal(self, event):
+        self.logger.info("ModeManager: Entering 'internal' state.")
+        self.stop_all_screens()
+        if self.library_manager:
+            self.library_manager.start_mode(service_type="internal", start_uri="music-library/INTERNAL")
+            self.logger.info("ModeManager: LibraryManager started for Internal.")
+        else:
+            self.logger.warning("ModeManager: No library_manager set.")
+        self.reset_idle_timer()
+        self.update_current_mode()
+
+    def enter_usb_library(self, event):
+        self.logger.info("ModeManager: Entering 'usblibrary' state.")
+        self.stop_all_screens()
+        if self.library_manager:
+            self.library_manager.start_mode(service_type="usblibrary", start_uri="music-library/USB")
+            self.logger.info("ModeManager: LibraryManager started for USB library.")
+        else:
+            self.logger.warning("ModeManager: No library_manager set.")
+        self.reset_idle_timer()
         self.update_current_mode()
 
     def enter_tidal(self, event):
         self.logger.info("ModeManager: Entering 'tidal' state.")
         self.stop_all_screens()
         if self.library_manager:
-            self.library_manager.start_mode(start_uri="tidal://")
+            self.library_manager.start_mode(service_type="tidal", start_uri="tidal://")
             self.logger.info("ModeManager: LibraryManager started for Tidal.")
         else:
             self.logger.warning("ModeManager: No library_manager set.")
@@ -709,7 +731,7 @@ class ModeManager:
         self.logger.info("ModeManager: Entering 'qobuz' state.")
         self.stop_all_screens()
         if self.library_manager:
-            self.library_manager.start_mode(start_uri="qobuz://")
+            self.library_manager.start_mode(service_type="qobuz", start_uri="qobuz://")
             self.logger.info("ModeManager: LibraryManager started for Qobuz.")
         else:
             self.logger.warning("ModeManager: No library_manager set.")
@@ -720,7 +742,7 @@ class ModeManager:
         self.logger.info("ModeManager: Entering 'spotify' state.")
         self.stop_all_screens()
         if self.library_manager:
-            self.library_manager.start_mode(start_uri="spop://")
+            self.library_manager.start_mode(service_type="spotify", start_uri="spop://")
             self.logger.info("ModeManager: LibraryManager started for Spotify.")
         else:
             self.logger.warning("ModeManager: No library_manager set.")
@@ -728,32 +750,21 @@ class ModeManager:
         self.update_current_mode()
 
     def enter_playlists(self, event):
-        self.logger.info("ModeManager: Entering 'albums' state.")
+        self.logger.info("ModeManager: Entering 'playlists' state.")
         self.stop_all_screens()
         if self.library_manager:
-            self.library_manager.start_mode(start_uri="playlists://")
+            self.library_manager.start_mode(service_type="playlists", start_uri="playlists://")
             self.logger.info("ModeManager: LibraryManager started for Playlists.")
         else:
             self.logger.warning("ModeManager: No library_manager set.")
         self.reset_idle_timer()
         self.update_current_mode()
 
-    def enter_playlists(self, event):
-        self.logger.info("ModeManager: Entering 'albums' state.")
+    def enter_radiomanager(self, event):
+        self.logger.info("ModeManager: Entering 'webradio' state.")
         self.stop_all_screens()
         if self.library_manager:
-            self.library_manager.start_mode(start_uri="playlists://")
-            self.logger.info("ModeManager: LibraryManager started for Playlists.")
-        else:
-            self.logger.warning("ModeManager: No library_manager set.")
-        self.reset_idle_timer()
-        self.update_current_mode()
-
-    def enter_webradio(self, event):
-        self.logger.info("ModeManager: Entering 'albums' state.")
-        self.stop_all_screens()
-        if self.library_manager:
-            self.library_manager.start_mode(start_uri="webradio://")
+            self.library_manager.start_mode(service_type="webradio", start_uri="webradio://")
             self.logger.info("ModeManager: LibraryManager started for WebRadio.")
         else:
             self.logger.warning("ModeManager: No library_manager set.")
@@ -764,7 +775,7 @@ class ModeManager:
         self.logger.info("ModeManager: Entering 'albums' state.")
         self.stop_all_screens()
         if self.library_manager:
-            self.library_manager.start_mode(start_uri="albums://")
+            self.library_manager.start_mode(service_type="albums", start_uri="albums://")
             self.logger.info("ModeManager: LibraryManager started for Albums.")
         else:
             self.logger.warning("ModeManager: No library_manager set.")
@@ -775,7 +786,7 @@ class ModeManager:
         self.logger.info("ModeManager: Entering 'genres' state.")
         self.stop_all_screens()
         if self.library_manager:
-            self.library_manager.start_mode(start_uri="genres://")
+            self.library_manager.start_mode(service_type="genres", start_uri="genres://")
             self.logger.info("ModeManager: LibraryManager started for Genres.")
         else:
             self.logger.warning("ModeManager: No library_manager set.")
@@ -786,7 +797,7 @@ class ModeManager:
         self.logger.info("ModeManager: Entering 'artists' state.")
         self.stop_all_screens()
         if self.library_manager:
-            self.library_manager.start_mode(start_uri="artists://")
+            self.library_manager.start_mode(service_type="artists", start_uri="artists://")
             self.logger.info("ModeManager: LibraryManager started for Artist.")
         else:
             self.logger.warning("ModeManager: No library_manager set.")
@@ -797,7 +808,7 @@ class ModeManager:
         self.logger.info("ModeManager: Entering 'favourites' state.")
         self.stop_all_screens()
         if self.library_manager:
-            self.library_manager.start_mode(start_uri="favourites")
+            self.library_manager.start_mode(service_type="favourites", start_uri="favourites")
             self.logger.info("ModeManager: LibraryManager started for favourites.")
         else:
             self.logger.warning("ModeManager: No library_manager set.")
@@ -808,7 +819,7 @@ class ModeManager:
         self.logger.info("ModeManager: Entering 'last100' state.")
         self.stop_all_screens()
         if self.library_manager:
-            self.library_manager.start_mode(start_uri="Last_100")
+            self.library_manager.start_mode(service_type="last100", start_uri="Last_100")
             self.logger.info("ModeManager: LibraryManager started for Last 100.")
         else:
             self.logger.warning("ModeManager: No library_manager set.")
@@ -819,7 +830,7 @@ class ModeManager:
         self.logger.info("ModeManager: Entering 'media servers' state.")
         self.stop_all_screens()
         if self.library_manager:
-            self.library_manager.start_mode(start_uri="upnp")
+            self.library_manager.start_mode(service_type="upnp", start_uri="upnp")
             self.logger.info("ModeManager: LibraryManager started for Media Servers.")
         else:
             self.logger.warning("ModeManager: No library_manager set.")


### PR DESCRIPTION
## Summary
- standardize menu look using text lists
- allow LibraryManager to browse any service
- hook ModeManager states to the unified LibraryManager

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688cdbe7da84833184584e8d5f7e6f9b